### PR TITLE
Make TextyTextView.style Optional, and update the example project to fit.

### DIFF
--- a/Example/Pods/Target Support Files/Pods-Texty_Example/Pods-Texty_Example-acknowledgements.markdown
+++ b/Example/Pods/Target Support Files/Pods-Texty_Example/Pods-Texty_Example-acknowledgements.markdown
@@ -3,7 +3,7 @@ This application makes use of the following third party libraries:
 
 ## Texty
 
-Copyright (c) 2017 Vectorform, LLC
+Copyright (c) 2018 Vectorform, LLC
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/Example/Pods/Target Support Files/Pods-Texty_Example/Pods-Texty_Example-acknowledgements.plist
+++ b/Example/Pods/Target Support Files/Pods-Texty_Example/Pods-Texty_Example-acknowledgements.plist
@@ -14,7 +14,7 @@
 		</dict>
 		<dict>
 			<key>FooterText</key>
-			<string>Copyright (c) 2017 Vectorform, LLC
+			<string>Copyright (c) 2018 Vectorform, LLC
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -30,7 +30,7 @@ are permitted provided that the following conditions are met:
    be used to endorse or promote products derived from this software without
    specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
 IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,

--- a/Example/Texty_Example.xcodeproj/project.pbxproj
+++ b/Example/Texty_Example.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		67CFF7121E412AE600352CA5 /* PopupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CFF7111E412AE600352CA5 /* PopupView.swift */; };
 		67CFF7141E4136C100352CA5 /* AdjustValueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CFF7131E4136C100352CA5 /* AdjustValueView.swift */; };
 		67CFF7161E413BF300352CA5 /* AdjustSizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67CFF7151E413BF300352CA5 /* AdjustSizeView.swift */; };
+		78BE7E232162C72A006C1451 /* UIControlEvent+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BE7E222162C72A006C1451 /* UIControlEvent+Extensions.swift */; };
+		78BE7E262162C7A4006C1451 /* ModificationButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BE7E252162C7A4006C1451 /* ModificationButton.swift */; };
 		F0653ED31ECA411C00F53406 /* TextViewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0653ED21ECA411C00F53406 /* TextViewViewController.swift */; };
 		F0E458651EB4133B00FFA725 /* ButtonViewController1.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E458631EB4133B00FFA725 /* ButtonViewController1.swift */; };
 		F0E458661EB4133B00FFA725 /* ButtonViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0E458641EB4133B00FFA725 /* ButtonViewController2.swift */; };
@@ -52,6 +54,8 @@
 		67CFF7111E412AE600352CA5 /* PopupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PopupView.swift; sourceTree = "<group>"; };
 		67CFF7131E4136C100352CA5 /* AdjustValueView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustValueView.swift; sourceTree = "<group>"; };
 		67CFF7151E413BF300352CA5 /* AdjustSizeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdjustSizeView.swift; sourceTree = "<group>"; };
+		78BE7E222162C72A006C1451 /* UIControlEvent+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControlEvent+Extensions.swift"; sourceTree = "<group>"; };
+		78BE7E252162C7A4006C1451 /* ModificationButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModificationButton.swift; sourceTree = "<group>"; };
 		B636608ED4C58AE54F7CAFC2 /* Pods_Texty_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Texty_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F020651B2A3625F79F3C906D /* Pods-Texty_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Texty_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Texty_Example/Pods-Texty_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F0653ED21ECA411C00F53406 /* TextViewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextViewViewController.swift; sourceTree = "<group>"; };
@@ -102,10 +106,10 @@
 			children = (
 				672577F41E3A88A000E04DEE /* AppDelegate.swift */,
 				67CFF70D1E3FE49700352CA5 /* Styles.swift */,
-				F0653ED41ECA412100F53406 /* TextViewViewController */,
+				78BE7E202162C6F7006C1451 /* Extensions */,
 				6746E64A1E4277A900C29100 /* Popups */,
-				F054A0751EB3E2D1000B32B6 /* ButtonViewController */,
-				6746E6491E42778E00C29100 /* LabelViewController */,
+				78BE7E212162C709006C1451 /* Sections */,
+				78BE7E242162C795006C1451 /* Views */,
 				672577FB1E3A88A000E04DEE /* Assets.xcassets */,
 				672577FD1E3A88A000E04DEE /* LaunchScreen.storyboard */,
 				672578001E3A88A000E04DEE /* Info.plist */,
@@ -132,6 +136,32 @@
 				67CFF7111E412AE600352CA5 /* PopupView.swift */,
 			);
 			name = Popups;
+			sourceTree = "<group>";
+		};
+		78BE7E202162C6F7006C1451 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				78BE7E222162C72A006C1451 /* UIControlEvent+Extensions.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		78BE7E212162C709006C1451 /* Sections */ = {
+			isa = PBXGroup;
+			children = (
+				F054A0751EB3E2D1000B32B6 /* ButtonViewController */,
+				6746E6491E42778E00C29100 /* LabelViewController */,
+				F0653ED41ECA412100F53406 /* TextViewViewController */,
+			);
+			name = Sections;
+			sourceTree = "<group>";
+		};
+		78BE7E242162C795006C1451 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				78BE7E252162C7A4006C1451 /* ModificationButton.swift */,
+			);
+			name = Views;
 			sourceTree = "<group>";
 		};
 		F054A0751EB3E2D1000B32B6 /* ButtonViewController */ = {
@@ -292,6 +322,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F0E458651EB4133B00FFA725 /* ButtonViewController1.swift in Sources */,
+				78BE7E262162C7A4006C1451 /* ModificationButton.swift in Sources */,
 				67CFF70E1E3FE49700352CA5 /* Styles.swift in Sources */,
 				6746E6481E425D2600C29100 /* AdjustAlignView.swift in Sources */,
 				67CFF7101E4129E900352CA5 /* AdjustColorView.swift in Sources */,
@@ -299,6 +330,7 @@
 				67CFF7141E4136C100352CA5 /* AdjustValueView.swift in Sources */,
 				67CFF7121E412AE600352CA5 /* PopupView.swift in Sources */,
 				67CFF7161E413BF300352CA5 /* AdjustSizeView.swift in Sources */,
+				78BE7E232162C72A006C1451 /* UIControlEvent+Extensions.swift in Sources */,
 				F0653ED31ECA411C00F53406 /* TextViewViewController.swift in Sources */,
 				6746E64C1E42784800C29100 /* AdjustKernView.swift in Sources */,
 				672577F51E3A88A000E04DEE /* AppDelegate.swift in Sources */,

--- a/Example/Texty_Example/AdjustAlignView.swift
+++ b/Example/Texty_Example/AdjustAlignView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/AdjustColorView.swift
+++ b/Example/Texty_Example/AdjustColorView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/AdjustKernView.swift
+++ b/Example/Texty_Example/AdjustKernView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/AdjustSizeView.swift
+++ b/Example/Texty_Example/AdjustSizeView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/AdjustValueView.swift
+++ b/Example/Texty_Example/AdjustValueView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/AppDelegate.swift
+++ b/Example/Texty_Example/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/ButtonViewController1.swift
+++ b/Example/Texty_Example/ButtonViewController1.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/ButtonViewController1.swift
+++ b/Example/Texty_Example/ButtonViewController1.swift
@@ -92,7 +92,7 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         NSLayoutConstraint(item: self.titleButton, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 10.0).isActive = true
         NSLayoutConstraint(item: self.titleButton, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -10.0).isActive = true
         
-        NSLayoutConstraint(item: self.changeColorButton, attribute: .width, relatedBy: .equal, toItem: self.view, attribute: .width, multiplier: 0.25, constant: -10.0).isActive = true
+        NSLayoutConstraint(item: self.changeColorButton, attribute: .width, relatedBy: .equal, toItem: self.view, attribute: .width, multiplier: (1.0 / 3.0), constant: -10.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 0.0, constant: 50.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
         if #available(iOS 11.0, *) {
@@ -140,6 +140,15 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         
         self.view.isUserInteractionEnabled = false
         
+        popup.alpha = 0.0
+        popup.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.view.addSubview(popup)
+        
+        NSLayoutConstraint(item: popup, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
+        NSLayoutConstraint(item: popup, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
+        NSLayoutConstraint(item: popup, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
+        
         UIView.animate(withDuration: 0.25, animations: {
             popup.alpha = 1.0
         }) { (result) in
@@ -156,20 +165,10 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         }
         
         var hue: CGFloat = 0.0
-       
         self.titleButton.titleColor(for: .normal)?.getHue(&hue, saturation: nil, brightness: nil, alpha: nil)
+        
         let colorView: AdjustColorView = AdjustColorView(hue: hue)
-        
-        colorView.alpha = 0.0
         colorView.delegate = self
-        colorView.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.view.addSubview(colorView)
-        
-        NSLayoutConstraint(item: colorView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: colorView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: colorView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
-        
         self.showPopup(colorView, completion: nil)
     }
     
@@ -181,19 +180,11 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         
         let kernView: AdjustKernView = AdjustKernView()
         
-        kernView.alpha = 0.0
         kernView.delegate = self
         kernView.maximumValue = 30.0
         kernView.minimumValue = 0.0
-        kernView.translatesAutoresizingMaskIntoConstraints = false
         kernView.value = Float(self.titleButton.style(for: .normal).kern == nil ? 0.0 : self.titleButton.style(for: .normal).kern!.floatValue)          //Has to be set after minimum/maximum values have been adjusted
-        
-        self.view.addSubview(kernView)
-        
-        NSLayoutConstraint(item: kernView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: kernView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: kernView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
-        
+
         self.showPopup(kernView, completion: nil)
     }
     
@@ -205,19 +196,11 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         
         let sizeView: AdjustSizeView = AdjustSizeView()
         
-        sizeView.alpha = 0.0
         sizeView.delegate = self
         sizeView.maximumValue = 30.0
         sizeView.minimumValue = 10.0
-        sizeView.translatesAutoresizingMaskIntoConstraints = false
         sizeView.value = Float((self.titleButton.titleLabel?.font.pointSize)!)          //Has to be set after minimum/maximum values have been adjusted
-        
-        self.view.addSubview(sizeView)
-        
-        NSLayoutConstraint(item: sizeView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: sizeView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: sizeView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
-        
+ 
         self.showPopup(sizeView, completion: nil)
     }
     

--- a/Example/Texty_Example/ButtonViewController1.swift
+++ b/Example/Texty_Example/ButtonViewController1.swift
@@ -30,74 +30,18 @@ import Foundation
 import UIKit
 import Texty
 
-
-fileprivate extension UIControl.Event {
-    
-    fileprivate static var allTouchDownEvents: UIControl.Event {
-        return UIControl.Event(rawValue: UIControl.Event.touchDragEnter.rawValue | UIControl.Event.touchDown.rawValue)
-    }
-    
-    fileprivate static var allTouchUpEvents: UIControl.Event {
-        return UIControl.Event(rawValue: UIControl.Event.touchCancel.rawValue | UIControl.Event.touchDragExit.rawValue | UIControl.Event.touchUpInside.rawValue | UIControl.Event.touchUpOutside.rawValue)
-    }
-    
-}
-
-
-fileprivate class VCButton: UIButton {
-    
-    convenience init() {
-        self.init(frame: .zero)
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        self.backgroundColor = UIColor.white
-        self.setTitleColor(UIColor.lightGray, for: .normal)
-        self.layer.borderColor = UIColor.lightGray.cgColor
-        self.layer.borderWidth = 3.0
-        self.layer.cornerRadius = 5.0
-        
-        self.addTarget(self, action: #selector(VCButton.onTouchDown), for: .allTouchDownEvents)
-        self.addTarget(self, action: #selector(VCButton.onTouchUp), for: .allTouchUpEvents)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("not supported")
-    }
-    
-    
-    @objc private func onTouchDown() {
-        self.backgroundColor = UIColor.lightGray
-        self.setTitleColor(UIColor.white, for: .normal)
-    }
-    
-    @objc private func onTouchUp() {
-        self.backgroundColor = UIColor.white
-        self.setTitleColor(UIColor.lightGray, for: .normal)
-    }
-    
-}
-
-
 class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
+    private let changeColorButton: ModificationButton = ModificationButton()
+    private let changeKernButton: ModificationButton = ModificationButton()
+    private let changeSizeButton: ModificationButton = ModificationButton()
     
-    private let changeColorButton: VCButton = VCButton()
-    private let changeKernButton: VCButton = VCButton()
-    private let changeSizeButton: VCButton = VCButton()
-    
-
-  
     private lazy var titleButton: TextyButton = {
         var style = TextStyle(with: Styles.Header)
         
         style.setAttributes([TextAttribute.obliqueness : 0.2], forTag: "italic")
         style.setAttributes([TextAttribute.underlineStyle : NSUnderlineStyle.single.rawValue], forTag: "underline")
     
-        
         let button = TextyButton(style: style)
-        
         var highlightedStyle = TextStyle(with: Styles.Header)
         
         highlightedStyle.setAttributes([TextAttribute.obliqueness : -0.5], forTag: "italic")
@@ -119,25 +63,24 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
     override func loadView() {
         super.loadView()
         
-        self.changeColorButton.addTarget(self, action: #selector(ButtonViewController1.changeColorButtonPressed), for: .touchUpInside)
+        self.changeColorButton.addTarget(self, action: #selector(changeColorButtonPressed), for: .touchUpInside)
         self.changeColorButton.setTitle("Color", for: .normal)
         self.changeColorButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.changeSizeButton.addTarget(self, action: #selector(ButtonViewController1.changeSizeButtonPressed), for: .touchUpInside)
+        self.changeSizeButton.addTarget(self, action: #selector(changeSizeButtonPressed), for: .touchUpInside)
         self.changeSizeButton.setTitle("Size", for: .normal)
         self.changeSizeButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.changeKernButton.addTarget(self, action: #selector(ButtonViewController1.changeKernButtonPressed), for: .touchUpInside)
+        self.changeKernButton.addTarget(self, action: #selector(changeKernButtonPressed), for: .touchUpInside)
         self.changeKernButton.setTitle("Kern", for: .normal)
         self.changeKernButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.titleButton.setTitle("This <italic>is a <underline>TextButton</italic> Example</underline>", for: .normal)
+        self.titleButton.setTitle("TextButton <italic>Example - <underline>Click </italic> Me</underline>", for: .normal)
         self.titleButton.setTitleColor(UIColor(hue: 0.0, saturation: 1.0, brightness: 1.0, alpha: 1.0), for: .normal)
         self.titleButton.translatesAutoresizingMaskIntoConstraints = false
         
         self.view.backgroundColor = UIColor.white
         self.view.frame = UIScreen.main.bounds
-        
         
         self.view.addSubview(self.titleButton)
         self.view.addSubview(self.changeColorButton)
@@ -151,8 +94,12 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         
         NSLayoutConstraint(item: self.changeColorButton, attribute: .width, relatedBy: .equal, toItem: self.view, attribute: .width, multiplier: 0.25, constant: -10.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 0.0, constant: 50.0).isActive = true
-        NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
+        if #available(iOS 11.0, *) {
+            NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        } else {
+            NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        }
         
         NSLayoutConstraint(item: self.changeSizeButton, attribute: .width, relatedBy: .equal, toItem: self.changeColorButton, attribute: .width, multiplier: 1.0, constant: 0.0).isActive = true
         NSLayoutConstraint(item: self.changeSizeButton, attribute: .height, relatedBy: .equal, toItem: self.changeColorButton, attribute: .height, multiplier: 1.0, constant: 0.0).isActive = true
@@ -164,7 +111,6 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         NSLayoutConstraint(item: self.changeKernButton, attribute: .left, relatedBy: .equal, toItem: self.changeSizeButton, attribute: .right, multiplier: 1.0, constant: 10.0).isActive = true
         NSLayoutConstraint(item: self.changeKernButton, attribute: .top, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: 0.0).isActive = true
     }
-    
     
     private func hideShownPopup(completion: (() -> Void)?) {
         guard let view = self.shownPopup else {
@@ -202,7 +148,6 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
             completion?()
         }
     }
-    
     
     @objc private func changeColorButtonPressed() {
         if let view = self.shownPopup, view is AdjustColorView {
@@ -276,7 +221,6 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
         self.showPopup(sizeView, completion: nil)
     }
     
-    
     func valueAdjusted(view: AdjustValueView) {
         if(view is AdjustColorView) {
             self.titleButton.setTitleColor((view as! AdjustColorView).color, for: .normal)
@@ -286,5 +230,4 @@ class ButtonViewController1: UIViewController, AdjustValueViewDelegate {
             self.titleButton.style(for: .normal).kern = NSNumber(value: view.value)
         }
     }
-    
 }

--- a/Example/Texty_Example/ButtonViewController2.swift
+++ b/Example/Texty_Example/ButtonViewController2.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/ButtonViewController2.swift
+++ b/Example/Texty_Example/ButtonViewController2.swift
@@ -30,12 +30,7 @@ import Foundation
 import UIKit
 import Texty
 
-
-
-
 class ButtonViewController2: UIViewController{
-    
-    
     override func loadView() {
         super.loadView()
         
@@ -88,12 +83,10 @@ class ButtonViewController2: UIViewController{
         textyButton5.setTitleShadowColor(UIColor.yellow, for: .highlighted)
         textyButton5.titleLabel?.shadowOffset = CGSize(width: 2.0, height: 2.0);
         
-        
         let uiButtonStackView = UIStackView(arrangedSubviews: [test1Buttons[0],test2Buttons[0],test3Buttons[0],test4Buttons[0],uiButton5])
         uiButtonStackView.axis = .vertical
         uiButtonStackView.spacing = 10
         uiButtonStackView.distribution = .fillEqually
-        
         
         let textyButtonStackView = UIStackView(arrangedSubviews: [test1Buttons[1],test2Buttons[1],test3Buttons[1],test4Buttons[1],textyButton5])
         textyButtonStackView.axis = .vertical
@@ -110,12 +103,13 @@ class ButtonViewController2: UIViewController{
         
         NSLayoutConstraint(item: columnStackView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 0.0).isActive = true
         NSLayoutConstraint(item: columnStackView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: 0.0).isActive = true
-        NSLayoutConstraint(item: columnStackView, attribute: .top, relatedBy: .equal, toItem: self.view, attribute: .top, multiplier: 1.0, constant: 0.0).isActive = true
-        NSLayoutConstraint(item: columnStackView, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
-        
-        
+    
+        if #available(iOS 11.0, *) {
+            NSLayoutConstraint(item: columnStackView, attribute: .top, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .top, multiplier: 1.0, constant: 0.0).isActive = true
+            NSLayoutConstraint(item: columnStackView, attribute: .bottom, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        } else {
+            NSLayoutConstraint(item: columnStackView, attribute: .top, relatedBy: .equal, toItem: self.view, attribute: .top, multiplier: 1.0, constant: 0.0).isActive = true
+            NSLayoutConstraint(item: columnStackView, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        }
     }
-    
-    
-    
 }

--- a/Example/Texty_Example/LabelViewController.swift
+++ b/Example/Texty_Example/LabelViewController.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/LabelViewController.swift
+++ b/Example/Texty_Example/LabelViewController.swift
@@ -30,63 +30,11 @@ import Foundation
 import UIKit
 import Texty
 
-
-fileprivate extension UIControl.Event {
-    
-    fileprivate static var allTouchDownEvents: UIControl.Event {
-        return UIControl.Event(rawValue: UIControl.Event.touchDragEnter.rawValue | UIControl.Event.touchDown.rawValue)
-    }
-    
-    fileprivate static var allTouchUpEvents: UIControl.Event {
-        return UIControl.Event(rawValue: UIControl.Event.touchCancel.rawValue | UIControl.Event.touchDragExit.rawValue | UIControl.Event.touchUpInside.rawValue | UIControl.Event.touchUpOutside.rawValue)
-    }
-    
-}
-
-
-fileprivate class VCButton: UIButton {
-    
-    convenience init() {
-        self.init(frame: .zero)
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        self.backgroundColor = UIColor.white
-        self.setTitleColor(UIColor.lightGray, for: .normal)
-        self.layer.borderColor = UIColor.lightGray.cgColor
-        self.layer.borderWidth = 3.0
-        self.layer.cornerRadius = 5.0
-        
-        self.addTarget(self, action: #selector(VCButton.onTouchDown), for: .allTouchDownEvents)
-        self.addTarget(self, action: #selector(VCButton.onTouchUp), for: .allTouchUpEvents)
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("not supported")
-    }
-    
-    
-    @objc private func onTouchDown() {
-        self.backgroundColor = UIColor.lightGray
-        self.setTitleColor(UIColor.white, for: .normal)
-    }
-    
-    @objc private func onTouchUp() {
-        self.backgroundColor = UIColor.white
-        self.setTitleColor(UIColor.lightGray, for: .normal)
-    }
-    
-}
-
-
 class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlignViewDelegate {
-    
-    private let changeAlignButton: VCButton = VCButton()
-    private let changeColorButton: VCButton = VCButton()
-    private let changeKernButton: VCButton = VCButton()
-    private let changeSizeButton: VCButton = VCButton()
+    private let changeAlignButton: ModificationButton = ModificationButton()
+    private let changeColorButton: ModificationButton = ModificationButton()
+    private let changeKernButton: ModificationButton = ModificationButton()
+    private let changeSizeButton: ModificationButton = ModificationButton()
     
     private let titleLabel: TextyLabel = TextyLabel(style: Styles.Header)
     
@@ -96,19 +44,19 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
     override func loadView() {
         super.loadView()
     
-        self.changeColorButton.addTarget(self, action: #selector(LabelViewController.changeColorButtonPressed), for: .touchUpInside)
+        self.changeColorButton.addTarget(self, action: #selector(changeColorButtonPressed), for: .touchUpInside)
         self.changeColorButton.setTitle("Color", for: .normal)
         self.changeColorButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.changeSizeButton.addTarget(self, action: #selector(LabelViewController.changeSizeButtonPressed), for: .touchUpInside)
+        self.changeSizeButton.addTarget(self, action: #selector(changeSizeButtonPressed), for: .touchUpInside)
         self.changeSizeButton.setTitle("Size", for: .normal)
         self.changeSizeButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.changeAlignButton.addTarget(self, action: #selector(LabelViewController.changeAlignButtonPressed), for: .touchUpInside)
+        self.changeAlignButton.addTarget(self, action: #selector(changeAlignButtonPressed), for: .touchUpInside)
         self.changeAlignButton.setTitle("Align", for: .normal)
         self.changeAlignButton.translatesAutoresizingMaskIntoConstraints = false
         
-        self.changeKernButton.addTarget(self, action: #selector(LabelViewController.changeKernButtonPressed), for: .touchUpInside)
+        self.changeKernButton.addTarget(self, action: #selector(changeKernButtonPressed), for: .touchUpInside)
         self.changeKernButton.setTitle("Kern", for: .normal)
         self.changeKernButton.translatesAutoresizingMaskIntoConstraints = false
         
@@ -136,8 +84,12 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         
         NSLayoutConstraint(item: self.changeColorButton, attribute: .width, relatedBy: .equal, toItem: self.view, attribute: .width, multiplier: 0.25, constant: -10.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 0.0, constant: 50.0).isActive = true
-        NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
         NSLayoutConstraint(item: self.changeColorButton, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
+        if #available(iOS 11.0, *) {
+            NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        } else {
+            NSLayoutConstraint(item: self.changeColorButton, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        }
         
         NSLayoutConstraint(item: self.changeSizeButton, attribute: .width, relatedBy: .equal, toItem: self.changeColorButton, attribute: .width, multiplier: 1.0, constant: 0.0).isActive = true
         NSLayoutConstraint(item: self.changeSizeButton, attribute: .height, relatedBy: .equal, toItem: self.changeColorButton, attribute: .height, multiplier: 1.0, constant: 0.0).isActive = true
@@ -298,5 +250,4 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
             self.titleLabel.style.kern = NSNumber(value: view.value)
         }
     }
-    
 }

--- a/Example/Texty_Example/LabelViewController.swift
+++ b/Example/Texty_Example/LabelViewController.swift
@@ -136,6 +136,15 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         
         self.view.isUserInteractionEnabled = false
         
+        popup.alpha = 0.0
+        popup.translatesAutoresizingMaskIntoConstraints = false
+        
+        self.view.addSubview(popup)
+        
+        NSLayoutConstraint(item: popup, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
+        NSLayoutConstraint(item: popup, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
+        NSLayoutConstraint(item: popup, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
+        
         UIView.animate(withDuration: 0.25, animations: { 
             popup.alpha = 1.0
         }) { (result) in
@@ -152,17 +161,7 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         }
         
         let alignView: AdjustAlignView = AdjustAlignView(alignment: self.titleLabel.textAlignment)
-        
-        alignView.alpha = 0.0
         alignView.delegate = self
-        alignView.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.view.addSubview(alignView)
-        
-        NSLayoutConstraint(item: alignView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: alignView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: alignView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
-        
         self.showPopup(alignView, completion: nil)
     }
     
@@ -174,18 +173,9 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         
         var hue: CGFloat = 0.0
         self.titleLabel.textColor.getHue(&hue, saturation: nil, brightness: nil, alpha: nil)
+        
         let colorView: AdjustColorView = AdjustColorView(hue: hue)
-        
-        colorView.alpha = 0.0
         colorView.delegate = self
-        colorView.translatesAutoresizingMaskIntoConstraints = false
-        
-        self.view.addSubview(colorView)
-        
-        NSLayoutConstraint(item: colorView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: colorView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: colorView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
-        
         self.showPopup(colorView, completion: nil)
     }
     
@@ -197,18 +187,10 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         
         let kernView: AdjustKernView = AdjustKernView()
         
-        kernView.alpha = 0.0
         kernView.delegate = self
         kernView.maximumValue = 30.0
         kernView.minimumValue = 0.0
-        kernView.translatesAutoresizingMaskIntoConstraints = false
         kernView.value = Float(self.titleLabel.style.kern == nil ? 0.0 : self.titleLabel.style.kern!.floatValue)          //Has to be set after minimum/maximum values have been adjusted
-        
-        self.view.addSubview(kernView)
-        
-        NSLayoutConstraint(item: kernView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: kernView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: kernView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
         
         self.showPopup(kernView, completion: nil)
     }
@@ -221,18 +203,10 @@ class LabelViewController: UIViewController, AdjustValueViewDelegate, AdjustAlig
         
         let sizeView: AdjustSizeView = AdjustSizeView()
         
-        sizeView.alpha = 0.0
         sizeView.delegate = self
         sizeView.maximumValue = 30.0
         sizeView.minimumValue = 10.0
-        sizeView.translatesAutoresizingMaskIntoConstraints = false
         sizeView.value = Float(self.titleLabel.font.pointSize)          //Has to be set after minimum/maximum values have been adjusted
-        
-        self.view.addSubview(sizeView)
-        
-        NSLayoutConstraint(item: sizeView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 5.0).isActive = true
-        NSLayoutConstraint(item: sizeView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: -5.0).isActive = true
-        NSLayoutConstraint(item: sizeView, attribute: .bottom, relatedBy: .equal, toItem: self.changeColorButton, attribute: .top, multiplier: 1.0, constant: -15.0).isActive = true
         
         self.showPopup(sizeView, completion: nil)
     }

--- a/Example/Texty_Example/ModificationButton.swift
+++ b/Example/Texty_Example/ModificationButton.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -25,15 +25,38 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 import Foundation
 import UIKit
-import Texty
 
-struct Styles {
+class ModificationButton: UIButton {
+    convenience init() {
+        self.init(frame: .zero)
+    }
     
-    static let Header: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.boldSystemFont(ofSize: 24.0)])
-    static let Body: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.systemFont(ofSize: 12.0)])
-    static let PopupHeader: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.systemFont(ofSize: 20.0)])
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = UIColor.white
+        self.setTitleColor(UIColor.lightGray, for: .normal)
+        self.layer.borderColor = UIColor.lightGray.cgColor
+        self.layer.borderWidth = 3.0
+        self.layer.cornerRadius = 5.0
+        
+        self.addTarget(self, action: #selector(onTouchDown), for: .allTouchDownEvents)
+        self.addTarget(self, action: #selector(onTouchUp), for: .allTouchUpEvents)
+    }
     
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("not supported")
+    }
+    
+    @objc private func onTouchDown() {
+        self.backgroundColor = UIColor.lightGray
+        self.setTitleColor(UIColor.white, for: .normal)
+    }
+    
+    @objc private func onTouchUp() {
+        self.backgroundColor = UIColor.white
+        self.setTitleColor(UIColor.lightGray, for: .normal)
+    }
 }

--- a/Example/Texty_Example/PopupView.swift
+++ b/Example/Texty_Example/PopupView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/Styles.swift
+++ b/Example/Texty_Example/Styles.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/TextViewViewController.swift
+++ b/Example/Texty_Example/TextViewViewController.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Example/Texty_Example/TextViewViewController.swift
+++ b/Example/Texty_Example/TextViewViewController.swift
@@ -30,33 +30,43 @@ import Foundation
 import UIKit
 import Texty
 
+fileprivate let BodyText: String = """
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sagittis pellentesque elementum. Suspendisse potenti. Vivamus ut nibh dapibus, suscipit magna vitae, mattis nisi. Mauris metus arcu, vulputate vitae leo sit amet, mattis molestie ex. Donec maximus vulputate est, at imperdiet ex. Nulla vel lectus ut diam sagittis ornare eu vitae enim. Etiam sed ligula euismod, congue nibh vel, tincidunt leo. Phasellus vel purus turpis. Nullam libero purus, posuere quis bibendum eget, scelerisque eu metus. Ut a ante ante. In tincidunt fringilla arcu, eu vehicula metus cursus ac. Donec non risus at lorem tincidunt placerat id vel sem. Vivamus iaculis felis metus, sed interdum massa accumsan eu.
 
+Etiam congue turpis lorem, non vehicula est iaculis vitae. Ut nibh diam, suscipit vitae purus in, finibus laoreet odio. In hac habitasse platea dictumst. Donec in risus vel neque luctus gravida. Nulla non consectetur orci, id gravida nunc. Nam posuere mi ut nisl fermentum fermentum. Aenean elementum tellus feugiat neque suscipit, sit amet consequat libero egestas. Nullam iaculis auctor massa, id consectetur velit tempor elementum. Aenean blandit nulla mollis imperdiet imperdiet. Mauris ornare ante ligula, et feugiat lacus tincidunt eget. Duis posuere lectus elit, non cursus est consectetur nec. Pellentesque massa orci, rhoncus non eleifend sed, bibendum sit amet massa. Proin ornare purus non maximus sodales. Praesent maximus sollicitudin luctus.
 
+Donec magna nunc, pharetra eget tellus sit amet, dignissim rutrum sapien. Vivamus interdum, libero in pharetra fringilla, turpis orci ornare elit, eu consequat ipsum sapien non ligula. Sed tempus euismod pharetra. Curabitur euismod accumsan nisi, eu mattis ipsum laoreet at. Donec molestie sit amet urna nec rhoncus. Fusce porta dolor massa, convallis auctor turpis fringilla et. Aliquam id lectus orci. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+In faucibus pharetra ultrices. Proin fermentum pellentesque posuere. Etiam tortor magna, scelerisque a turpis dictum, ornare interdum nisl. Suspendisse vitae orci tortor. Nam a gravida diam. Cras in faucibus magna, quis dapibus enim. Phasellus euismod risus in malesuada fermentum. Sed lacinia felis nisl, at pharetra ipsum aliquam in. Sed et lacus convallis, placerat mi sit amet, tempus velit.
+
+Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed semper augue sem, at egestas augue pretium ut. Integer mattis volutpat interdum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc auctor dolor urna, nec malesuada augue imperdiet eget. Donec tempus molestie urna id convallis. Vivamus facilisis pharetra euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus aliquet sem eu tellus efficitur vulputate.
+"""
 
 class TextViewViewController: UIViewController{
-    
+    private let textView: TextyTextView = TextyTextView(style: TextStyle())
     
     override func loadView() {
         super.loadView()
         
+        self.textView.style!.setStyle(Styles.Header, forTag: "header")
+        self.textView.style!.setStyle(Styles.Body, forTag: "body")
+        
+        self.textView.translatesAutoresizingMaskIntoConstraints = false
+        self.textView.text = "<header>TextyTextView</header>\n\n<body>\(BodyText)</body>"
+        
         self.view.backgroundColor = UIColor.white
         
-        let textView = TextyTextView(style: Styles.Header)
-        textView.text = "this text is not editable this text is not editable this text is not editable hello@gmail.com"
-        textView.isEditable = false
-        textView.dataDetectorTypes = .all
-        self.view.addSubview(textView)
+        self.view.addSubview(self.textView)
         
-        textView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint(item: self.textView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 0.0).isActive = true
+        NSLayoutConstraint(item: self.textView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: 0.0).isActive = true
         
-        NSLayoutConstraint(item: textView, attribute: .left, relatedBy: .equal, toItem: self.view, attribute: .left, multiplier: 1.0, constant: 0.0).isActive = true
-        NSLayoutConstraint(item: textView, attribute: .right, relatedBy: .equal, toItem: self.view, attribute: .right, multiplier: 1.0, constant: 0.0).isActive = true
-        NSLayoutConstraint(item: textView, attribute: .top, relatedBy: .equal, toItem: self.view, attribute: .top, multiplier: 1.0, constant: 60.0).isActive = true
-        NSLayoutConstraint(item: textView, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
-        
-        
+        if #available(iOS 11.0, *) {
+            NSLayoutConstraint(item: self.textView, attribute: .top, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .top, multiplier: 1.0, constant: 60.0).isActive = true
+            NSLayoutConstraint(item: self.textView, attribute: .bottom, relatedBy: .equal, toItem: self.view.safeAreaLayoutGuide, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        } else {
+            NSLayoutConstraint(item: self.textView, attribute: .top, relatedBy: .equal, toItem: self.view, attribute: .top, multiplier: 1.0, constant: 60.0).isActive = true
+            NSLayoutConstraint(item: self.textView, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
+        }
     }
-    
-    
-    
 }

--- a/Example/Texty_Example/TextViewViewController.swift
+++ b/Example/Texty_Example/TextViewViewController.swift
@@ -69,4 +69,9 @@ class TextViewViewController: UIViewController{
             NSLayoutConstraint(item: self.textView, attribute: .bottom, relatedBy: .equal, toItem: self.view, attribute: .bottom, multiplier: 1.0, constant: -60.0).isActive = true
         }
     }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        self.textView.setContentOffset(CGPoint(x: 0.0, y: 0.0), animated: false)
+    }
 }

--- a/Example/Texty_Example/UIControlEvent+Extensions.swift
+++ b/Example/Texty_Example/UIControlEvent+Extensions.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -25,15 +25,15 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-
 import Foundation
 import UIKit
-import Texty
 
-struct Styles {
+extension UIControl.Event {
+    static var allTouchDownEvents: UIControl.Event {
+        return UIControl.Event(rawValue: UIControl.Event.touchDragEnter.rawValue | UIControl.Event.touchDown.rawValue)
+    }
     
-    static let Header: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.boldSystemFont(ofSize: 24.0)])
-    static let Body: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.systemFont(ofSize: 12.0)])
-    static let PopupHeader: TextStyle = TextStyle(attributes: [.foregroundColor : UIColor.black, .font : UIFont.systemFont(ofSize: 20.0)])
-    
+    static var allTouchUpEvents: UIControl.Event {
+        return UIControl.Event(rawValue: UIControl.Event.touchCancel.rawValue | UIControl.Event.touchDragExit.rawValue | UIControl.Event.touchUpInside.rawValue | UIControl.Event.touchUpOutside.rawValue)
+    }
 }

--- a/Source/Scanner.swift
+++ b/Source/Scanner.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/String.swift
+++ b/Source/String.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/Tag.swift
+++ b/Source/Tag.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextAttribute.swift
+++ b/Source/TextAttribute.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextStyle.swift
+++ b/Source/TextStyle.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextStyle.swift
+++ b/Source/TextStyle.swift
@@ -79,8 +79,10 @@ public class TextStyle {
         self.delegate?.didUpdate(style: self)
     }
     
-    public func attributedString(with string: String) -> NSAttributedString {
-        var mutableString: String = string
+    public func attributedString(with string: String?) -> NSAttributedString? {
+        guard var mutableString: String = string else {
+            return nil
+        }
         var attributedString: NSMutableAttributedString
         
         if(self.taggedAttributes.count > 0) {

--- a/Source/TextyButton.swift
+++ b/Source/TextyButton.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextyLabel.swift
+++ b/Source/TextyLabel.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextyTextView.swift
+++ b/Source/TextyTextView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Vectorform, LLC
+// Copyright (c) 2018 Vectorform, LLC
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/Source/TextyTextView.swift
+++ b/Source/TextyTextView.swift
@@ -29,102 +29,112 @@
 import Foundation
 import UIKit
 
-// Texty Text View Currently DOES NOT SUPPORT EDITING
 open class TextyTextView: UITextView, TextStyleDelegate {
-    
-    // A copy will be created when setting this property
-    public var style: TextStyle!{
-        didSet{
-            self.style = TextStyle(with: style)
+    public var style: TextStyle? {
+        willSet { self.style?.delegate = nil }
+        didSet {
+            if let newStyle: TextStyle = self.style {
+                self.style = TextStyle(with: newStyle)
+                newStyle.delegate = self
+            }
             
-            let possiblyTaggedText = self.possiblyTaggedText
-            
-            // Set the delegate on the style
-            style.delegate = self
-            
-            // Finally, set the title again to let the style take effect
-            self.text = possiblyTaggedText
+            self.redrawText()
         }
     }
     
-    /// In each of the below setters, style is accessed using self.style? because
-    /// the super.init() call will attempt to set default values, at which point
-    /// style does not exist yet.
+    // The purpose of this variable is to keep a reference to the original text, including all contained tags. Once a
+    // style is applied to a string, all tags are stripped and lost forever.
+    private var taggedText: String?
     
-    open override var font: UIFont! {
-        get { return self.style.font }
-        set { self.style?.font = newValue }
-    }
-  
-    internal var possiblyTaggedText: String?            //A seperate property is needed in order to support tags properly
-    open override var text: String? {
-        get { return self.attributedText?.string }
+    open override var font: UIFont? {
+        get { return self.style?.font ?? super.font }
         set {
-            self.possiblyTaggedText = newValue
-            self.attributedText = newValue == nil ? nil : self.style.attributedString(with: newValue!)
+            if let style: TextStyle = self.style {
+                style.font = newValue
+            } else {
+                super.font = newValue
+            }
+        }
+    }
+    
+    open override var text: String? {
+        get { return (self.style == nil ? super.text : self.attributedText?.string) }
+        set {
+            self.taggedText = newValue
+            self.redrawText()
         }
     }
     
     open override var textAlignment: NSTextAlignment {
-        get { return self.style.paragraphStyle!.alignment }
+        get { return self.style?.paragraphStyle!.alignment ?? super.textAlignment }
         set {
-            let pstyle: NSMutableParagraphStyle = self.style.paragraphStyle!.mutableCopy() as! NSMutableParagraphStyle
-            pstyle.alignment = newValue
-            self.style.paragraphStyle = pstyle
+            if let style: TextStyle = self.style {
+                let paragraphStyle: NSMutableParagraphStyle = style.paragraphStyle!.mutableCopy() as! NSMutableParagraphStyle
+                paragraphStyle.alignment = newValue
+                style.paragraphStyle = paragraphStyle
+            } else {
+                super.textAlignment = newValue
+            }
         }
     }
     
     open override var textColor: UIColor! {
-        get { return self.style.foregroundColor }
-        set { self.style?.foregroundColor = newValue }
+        get { return self.style?.foregroundColor ?? super.textColor }
+        set {
+            if let style: TextStyle = self.style {
+                style.foregroundColor = newValue
+            } else {
+                super.textColor = newValue
+            }
+        }
     }
-    
     
     public convenience init() {
         self.init(style: TextStyle())
     }
     
-    // A copy of style will be created
-    public required init(style: TextStyle, frame: CGRect = .zero) {
-        
-        
+    public required init(style: TextStyle?, frame: CGRect = .zero) {
         super.init(frame: frame, textContainer: nil)
-        // Set style and ensure that didSet is called
-        ({
-            self.style = style
-            self.setDefaults()
-            self.style.delegate = self
-        })()
+        self.isEditable = false
+        
+        // Ensure didSet is called in self.style
+        ({ self.style = style })()
+        
+        // Set defaults values where needed
+        if let style: TextStyle = self.style {
+            if style.font == nil {
+                style.font = super.font
+            }
+            
+            if style.foregroundColor == nil {
+                style.foregroundColor = super.textColor
+            }
+            
+            if style.paragraphStyle == nil {
+                let paragraphStyle: NSMutableParagraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.alignment = .natural
+                paragraphStyle.lineBreakMode = .byWordWrapping
+                style.paragraphStyle = paragraphStyle
+            }
+        }
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        fatalError("not supported")
-    }
-    
-    
-    private func setDefaults() {
-        /// If the font/textColor are not set yet by the TextStyle passed in, then set some default values
-        self.text = nil
-        
-        if self.style.font == nil  {
-            self.style.font = super.font
-        }
-        
-        if self.style.foregroundColor == nil {
-            self.style.foregroundColor = super.textColor
-        }
-        
-        if self.style.paragraphStyle == nil {
-            let pstyle: NSMutableParagraphStyle = NSMutableParagraphStyle()
-            pstyle.alignment = .natural
-            pstyle.lineBreakMode = .byWordWrapping
-            self.style.paragraphStyle = pstyle
-        }
+        super.init(coder: aDecoder)
+        self.isEditable = false
     }
     
     internal func didUpdate(style: TextStyle) {
-        /// Update attributed string with new attributes called by the textStyle when it detects an update
-        self.text = possiblyTaggedText
+        self.redrawText()
     }
     
+    private func redrawText() {
+        if let style: TextStyle = self.style {
+            super.text = nil
+            self.attributedText = style.attributedString(with: self.taggedText)
+        } else {
+            self.attributedText = nil
+            super.text = self.taggedText
+        }
+    }
 }


### PR DESCRIPTION
- TextyTextView.style is now Optional to allow for initialization from a storyboard
- TextyStyle.attributedString now takes an Optional parameter and returns an Optional result because .attributedText is generally Optional
- Example project was updated for these changes
- Example project had all constraints updated to use .safeAreaLayout when on iOS 11.0+, and had unnecessary whitespace removed
- Example project had common UI elements moved into seperate files
- Copyright notice updated from 2017 to 2018